### PR TITLE
added support for jsonifying params using double curly braces - discuss please :-)

### DIFF
--- a/config/postgres.yaml
+++ b/config/postgres.yaml
@@ -10,5 +10,8 @@ dbs:
       data_range:
         name: "me.getpremiseranges"
         query: "SELECT * FROM {__name__}({premise_id});"
+      json_column:
+        name: "this_name_value_is_not_important"
+        query: "SELECT '{{an_object}}' AS col1;"
     access:
       read: true

--- a/lib/connection/postgres/SQLQuery.js
+++ b/lib/connection/postgres/SQLQuery.js
@@ -12,6 +12,14 @@ SQLQuery.prototype = {
 	build       : function( params ) {
 		params.__name__ = this.table.id;
 
-		return string.interpolate( this.query, params );
+		var re_jsonparams = /\$?\{{2}([^\}'"]+)\}{2}/g;
+
+		var jsonParsedQuery = String( this.query ).replace( re_jsonparams, function( m, p ) {
+			var newKey = '__' + p + ':as_json' + '__';
+			params[newKey] = JSON.stringify( params[p] );
+			return '{' + newKey + '}';
+		} );
+
+		return string.interpolate( jsonParsedQuery, params );
 	}
 };

--- a/test/lib/connection/postgres.test.js
+++ b/test/lib/connection/postgres.test.js
@@ -60,4 +60,26 @@ suite( 'suq.connection.postgres', function() {
 			} )( done );
 		} );
 	} );
+
+	suite( 'takes a query requiring a json object, then parses, jsonifies and interpolates it correctly , and returns expected results', function() {
+		test( 'connection/postgres', function( done ) {
+			co( function* () {
+				var db = yield require( '../../../' )( DEFAULTS.dbs );
+
+				var an_object = {
+					s: "string",
+					n: 42,
+					o: { 'foo': 'bar' },
+					a: [1,2,3]
+				};
+
+				var res = yield db.nipple.json_column.query( { an_object: an_object } );
+
+				expect( res.length ).to.equal( 1 );
+				expect( typeof res[0].col1  ).to.equal( "string" );
+				expect( function() { JSON.parse(res[0].col1); }).to.not.throw();
+				expect( JSON.parse(res[0].col1) ).to.deep.equal( an_object );
+			} )( done );
+		} );
+	} );
 } );


### PR DESCRIPTION
Didn't think this should go in string.interpolate, as it would break if optional "pattern" argument was passed in. But if someone has other ideas where this might work (one example would be to use a single regex rather than two different ones and somehow handle it in interpolate(), but there may be others), let me know...
